### PR TITLE
improve log-format

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -18,7 +18,9 @@ events {
 http {
     include /etc/nginx/mime.types;
 
-    access_log /dev/stdout;
+    log_format custom_cache_log_format '[CACHE $upstream_cache_status] $remote_addr - $remote_user [$time_local] '
+                    '"$request" $status $body_bytes_sent';
+    access_log /dev/stdout custom_cache_log_format;
 
     default_type application/octet-stream;
 


### PR DESCRIPTION
I think showing cache hit result suits this repository purpose, and hide ascii encoded non-readable request.

## Demo environment

`docker-compose up` with docker-compose.yml below

```
version: "3.5"
services:

  pypi-nginx-cache:
    image: nginx
    ports:
      - 80:8080
    volumes:
      - ./nginx.conf:/etc/nginx/nginx.conf

  user1:
    image: python:3.9
    environment:
      - PIP_INDEX_URL=http://pypi-nginx-cache:8080/simple
      - PIP_TRUSTED_HOST=pypi-nginx-cache
    depends_on:
      pypi-nginx-cache:
        condition: service_started
    command: "pip install requests"

  user2:
    image: python:3.9
    environment:
      - PIP_INDEX_URL=http://pypi-nginx-cache:8080/simple
      - PIP_TRUSTED_HOST=pypi-nginx-cache
    depends_on:
      user1:
        condition: service_completed_successfully
    command: "pip install requests"
```

## Before

```
Creating network "pypi-nginx-cache_default" with the default driver
Creating pypi-nginx-cache_pypi-nginx-cache_1 ... done
Creating pypi-nginx-cache_user1_1            ... done
Creating pypi-nginx-cache_user2_1            ... done
Attaching to pypi-nginx-cache_pypi-nginx-cache_1, pypi-nginx-cache_user1_1, pypi-nginx-cache_user2_1
pypi-nginx-cache_1  | /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
pypi-nginx-cache_1  | /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
user1_1             | Looking in indexes: http://pypi-nginx-cache:8080/simple
pypi-nginx-cache_1  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
pypi-nginx-cache_1  | 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
user1_1             | Collecting requests
user1_1             |   Downloading http://pypi-nginx-cache/packages/92/96/144f70b972a9c0eabbd4391ef93ccd49d0f2747f4f6a2a2738e99e5adc65/requests-2.26.0-py2.py3-none-any.whl (62 kB)
user1_1             | Collecting idna<4,>=2.5
user1_1             |   Downloading http://pypi-nginx-cache/packages/04/a2/d918dcd22354d8958fe113e1a3630137e0fc8b44859ade3063982eacd2a4/idna-3.3-py3-none-any.whl (61 kB)
user1_1             | Collecting urllib3<1.27,>=1.21.1
user1_1             |   Downloading http://pypi-nginx-cache/packages/af/f4/524415c0744552cce7d8bf3669af78e8a069514405ea4fcbd0cc44733744/urllib3-1.26.7-py2.py3-none-any.whl (138 kB)
user1_1             | Collecting certifi>=2017.4.17
user1_1             |   Downloading http://pypi-nginx-cache/packages/37/45/946c02767aabb873146011e665728b680884cd8fe70dde973c640e45b775/certifi-2021.10.8-py2.py3-none-any.whl (149 kB)
user1_1             | Collecting charset-normalizer~=2.0.0
user1_1             |   Downloading http://pypi-nginx-cache/packages/47/84/b06f6729fac8108c5fa3e13cde19b0b3de66ba5538c325496dbe39f5ff8e/charset_normalizer-2.0.9-py3-none-any.whl (39 kB)
user1_1             | Installing collected packages: urllib3, idna, charset-normalizer, certifi, requests
user1_1             | Successfully installed certifi-2021.10.8 charset-normalizer-2.0.9 idna-3.3 requests-2.26.0 urllib3-1.26.7
user1_1             | WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
user1_1             | WARNING: You are using pip version 21.2.4; however, version 21.3.1 is available.
user1_1             | You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
pypi-nginx-cache_1  | 10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
pypi-nginx-cache_1  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
pypi-nginx-cache_1  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
pypi-nginx-cache_1  | /docker-entrypoint.sh: Configuration complete; ready for start up
pypi-nginx-cache_1  | 2021/12/05 04:59:48 [notice] 1#1: using the "epoll" event method
pypi-nginx-cache_1  | 2021/12/05 04:59:48 [notice] 1#1: nginx/1.21.4
pypi-nginx-cache_1  | 2021/12/05 04:59:48 [notice] 1#1: built by gcc 10.2.1 20210110 (Debian 10.2.1-6)
pypi-nginx-cache_1  | 2021/12/05 04:59:48 [notice] 1#1: OS: Linux 5.10.47-linuxkit
pypi-nginx-cache_1  | 2021/12/05 04:59:48 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1048576:1048576
pypi-nginx-cache_1  | 2021/12/05 04:59:48 [notice] 1#1: start worker processes
pypi-nginx-cache_1  | 2021/12/05 04:59:48 [notice] 1#1: start worker process 32
pypi-nginx-cache_1  | 2021/12/05 04:59:48 [notice] 1#1: start worker process 33
pypi-nginx-cache_1  | 2021/12/05 04:59:48 [notice] 1#1: start worker process 34
pypi-nginx-cache_1  | 2021/12/05 04:59:48 [notice] 1#1: start worker process 35
pypi-nginx-cache_1  | 2021/12/05 04:59:48 [notice] 1#1: start cache manager process 36
pypi-nginx-cache_1  | 2021/12/05 04:59:48 [notice] 1#1: start cache loader process 37
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:01 +0000] "GET /simple/requests/ HTTP/1.1" 200 20295 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:02 +0000] "GET /packages/92/96/144f70b972a9c0eabbd4391ef93ccd49d0f2747f4f6a2a2738e99e5adc65/requests-2.26.0-py2.py3-none-any.whl HTTP/1.1" 200 62251 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:02 +0000] "GET /simple/idna/ HTTP/1.1" 200 4217 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:03 +0000] "GET /packages/04/a2/d918dcd22354d8958fe113e1a3630137e0fc8b44859ade3063982eacd2a4/idna-3.3-py3-none-any.whl HTTP/1.1" 200 61160 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:03 +0000] "GET /simple/urllib3/ HTTP/1.1" 200 11624 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:03 +0000] "GET /packages/af/f4/524415c0744552cce7d8bf3669af78e8a069514405ea4fcbd0cc44733744/urllib3-1.26.7-py2.py3-none-any.whl HTTP/1.1" 200 138764 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:03 +0000] "GET /simple/certifi/ HTTP/1.1" 200 8101 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:04 +0000] "GET /packages/37/45/946c02767aabb873146011e665728b680884cd8fe70dde973c640e45b775/certifi-2021.10.8-py2.py3-none-any.whl HTTP/1.1" 200 149195 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:04 +0000] "GET /simple/charset-normalizer/ HTTP/1.1" 200 5721 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:04 +0000] "GET /packages/47/84/b06f6729fac8108c5fa3e13cde19b0b3de66ba5538c325496dbe39f5ff8e/charset_normalizer-2.0.9-py3-none-any.whl HTTP/1.1" 200 39257 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:06 +0000] "GET /simple/pip/ HTTP/1.1" 200 19865 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
pypi-nginx-cache_1  | 2021/12/05 05:00:07 [info] 32#32: *8 client 172.30.0.3 closed keepalive connection
pypi-nginx-cache_1  | 2021/12/05 05:00:07 [info] 32#32: *1 client 172.30.0.3 closed keepalive connection
pypi-nginx-cache_1  | 2021/12/05 05:00:07 [info] 32#32: *3 client 172.30.0.3 closed keepalive connection
pypi-nginx-cache_user1_1 exited with code 0
user2_1             | Looking in indexes: http://pypi-nginx-cache:8080/simple
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:18 +0000] "GET /simple/requests/ HTTP/1.1" 200 20295 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
user2_1             | Collecting requests
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:18 +0000] "GET /packages/92/96/144f70b972a9c0eabbd4391ef93ccd49d0f2747f4f6a2a2738e99e5adc65/requests-2.26.0-py2.py3-none-any.whl HTTP/1.1" 200 62251 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
user2_1             |   Downloading http://pypi-nginx-cache/packages/92/96/144f70b972a9c0eabbd4391ef93ccd49d0f2747f4f6a2a2738e99e5adc65/requests-2.26.0-py2.py3-none-any.whl (62 kB)
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:18 +0000] "GET /simple/urllib3/ HTTP/1.1" 200 11624 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
user2_1             | Collecting urllib3<1.27,>=1.21.1
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:19 +0000] "GET /packages/af/f4/524415c0744552cce7d8bf3669af78e8a069514405ea4fcbd0cc44733744/urllib3-1.26.7-py2.py3-none-any.whl HTTP/1.1" 200 138764 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
user2_1             |   Downloading http://pypi-nginx-cache/packages/af/f4/524415c0744552cce7d8bf3669af78e8a069514405ea4fcbd0cc44733744/urllib3-1.26.7-py2.py3-none-any.whl (138 kB)
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:19 +0000] "GET /simple/idna/ HTTP/1.1" 200 4217 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
user2_1             | Collecting idna<4,>=2.5
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:19 +0000] "GET /packages/04/a2/d918dcd22354d8958fe113e1a3630137e0fc8b44859ade3063982eacd2a4/idna-3.3-py3-none-any.whl HTTP/1.1" 200 61160 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
user2_1             |   Downloading http://pypi-nginx-cache/packages/04/a2/d918dcd22354d8958fe113e1a3630137e0fc8b44859ade3063982eacd2a4/idna-3.3-py3-none-any.whl (61 kB)
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:19 +0000] "GET /simple/certifi/ HTTP/1.1" 200 8101 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
user2_1             | Collecting certifi>=2017.4.17
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:19 +0000] "GET /packages/37/45/946c02767aabb873146011e665728b680884cd8fe70dde973c640e45b775/certifi-2021.10.8-py2.py3-none-any.whl HTTP/1.1" 200 149195 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
user2_1             |   Downloading http://pypi-nginx-cache/packages/37/45/946c02767aabb873146011e665728b680884cd8fe70dde973c640e45b775/certifi-2021.10.8-py2.py3-none-any.whl (149 kB)
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:19 +0000] "GET /simple/charset-normalizer/ HTTP/1.1" 200 5721 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
user2_1             | Collecting charset-normalizer~=2.0.0
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:19 +0000] "GET /packages/47/84/b06f6729fac8108c5fa3e13cde19b0b3de66ba5538c325496dbe39f5ff8e/charset_normalizer-2.0.9-py3-none-any.whl HTTP/1.1" 200 39257 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
user2_1             |   Downloading http://pypi-nginx-cache/packages/47/84/b06f6729fac8108c5fa3e13cde19b0b3de66ba5538c325496dbe39f5ff8e/charset_normalizer-2.0.9-py3-none-any.whl (39 kB)
user2_1             | Installing collected packages: urllib3, idna, charset-normalizer, certifi, requests
user2_1             | Successfully installed certifi-2021.10.8 charset-normalizer-2.0.9 idna-3.3 requests-2.26.0 urllib3-1.26.7
user2_1             | WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
pypi-nginx-cache_1  | 172.30.0.3 - - [05/Dec/2021:05:00:21 +0000] "GET /simple/pip/ HTTP/1.1" 200 19865 "-" "pip/21.2.4 {\x22ci\x22:null,\x22cpu\x22:\x22x86_64\x22,\x22distro\x22:{\x22id\x22:\x22bullseye\x22,\x22libc\x22:{\x22lib\x22:\x22glibc\x22,\x22version\x22:\x222.31\x22},\x22name\x22:\x22Debian GNU/Linux\x22,\x22version\x22:\x2211\x22},\x22implementation\x22:{\x22name\x22:\x22CPython\x22,\x22version\x22:\x223.9.9\x22},\x22installer\x22:{\x22name\x22:\x22pip\x22,\x22version\x22:\x2221.2.4\x22},\x22openssl_version\x22:\x22OpenSSL 1.1.1k  25 Mar 2021\x22,\x22python\x22:\x223.9.9\x22,\x22setuptools_version\x22:\x2257.5.0\x22,\x22system\x22:{\x22name\x22:\x22Linux\x22,\x22release\x22:\x225.10.47-linuxkit\x22}}"
user2_1             | WARNING: You are using pip version 21.2.4; however, version 21.3.1 is available.
user2_1             | You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
pypi-nginx-cache_1  | 2021/12/05 05:00:22 [info] 32#32: *11 client 172.30.0.3 closed keepalive connection
pypi-nginx-cache_1  | 2021/12/05 05:00:22 [info] 32#32: *9 client 172.30.0.3 closed keepalive connection
pypi-nginx-cache_1  | 2021/12/05 05:00:22 [info] 32#32: *10 client 172.30.0.3 closed keepalive connection
pypi-nginx-cache_user2_1 exited with code 0

```

## After

```
Creating network "pypi-nginx-cache_default" with the default driver
Creating pypi-nginx-cache_pypi-nginx-cache_1 ... done
Creating pypi-nginx-cache_user1_1            ... done
Creating pypi-nginx-cache_user2_1            ... done
Attaching to pypi-nginx-cache_pypi-nginx-cache_1, pypi-nginx-cache_user1_1, pypi-nginx-cache_user2_1
pypi-nginx-cache_1  | /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
pypi-nginx-cache_1  | /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
pypi-nginx-cache_1  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
pypi-nginx-cache_1  | 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
pypi-nginx-cache_1  | 10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
pypi-nginx-cache_1  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
pypi-nginx-cache_1  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
pypi-nginx-cache_1  | /docker-entrypoint.sh: Configuration complete; ready for start up
pypi-nginx-cache_1  | 2021/12/05 04:58:23 [notice] 1#1: using the "epoll" event method
pypi-nginx-cache_1  | 2021/12/05 04:58:23 [notice] 1#1: nginx/1.21.4
pypi-nginx-cache_1  | 2021/12/05 04:58:23 [notice] 1#1: built by gcc 10.2.1 20210110 (Debian 10.2.1-6)
pypi-nginx-cache_1  | 2021/12/05 04:58:23 [notice] 1#1: OS: Linux 5.10.47-linuxkit
pypi-nginx-cache_1  | 2021/12/05 04:58:23 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1048576:1048576
pypi-nginx-cache_1  | 2021/12/05 04:58:23 [notice] 1#1: start worker processes
pypi-nginx-cache_1  | 2021/12/05 04:58:23 [notice] 1#1: start worker process 32
user1_1             | Looking in indexes: http://pypi-nginx-cache:8080/simple
pypi-nginx-cache_1  | 2021/12/05 04:58:23 [notice] 1#1: start worker process 33
user1_1             | Collecting requests
user1_1             |   Downloading http://pypi-nginx-cache/packages/92/96/144f70b972a9c0eabbd4391ef93ccd49d0f2747f4f6a2a2738e99e5adc65/requests-2.26.0-py2.py3-none-any.whl (62 kB)
user1_1             | Collecting urllib3<1.27,>=1.21.1
user1_1             |   Downloading http://pypi-nginx-cache/packages/af/f4/524415c0744552cce7d8bf3669af78e8a069514405ea4fcbd0cc44733744/urllib3-1.26.7-py2.py3-none-any.whl (138 kB)
pypi-nginx-cache_1  | 2021/12/05 04:58:23 [notice] 1#1: start worker process 34
pypi-nginx-cache_1  | 2021/12/05 04:58:23 [notice] 1#1: start worker process 35
pypi-nginx-cache_1  | 2021/12/05 04:58:23 [notice] 1#1: start cache manager process 36
user1_1             | Collecting idna<4,>=2.5
pypi-nginx-cache_1  | 2021/12/05 04:58:23 [notice] 1#1: start cache loader process 37
user1_1             |   Downloading http://pypi-nginx-cache/packages/04/a2/d918dcd22354d8958fe113e1a3630137e0fc8b44859ade3063982eacd2a4/idna-3.3-py3-none-any.whl (61 kB)
user1_1             | Collecting certifi>=2017.4.17
pypi-nginx-cache_1  | [CACHE MISS] 172.29.0.3 - - [05/Dec/2021:04:58:34 +0000] "GET /simple/requests/ HTTP/1.1" 200 20295
user1_1             |   Downloading http://pypi-nginx-cache/packages/37/45/946c02767aabb873146011e665728b680884cd8fe70dde973c640e45b775/certifi-2021.10.8-py2.py3-none-any.whl (149 kB)
pypi-nginx-cache_1  | [CACHE MISS] 172.29.0.3 - - [05/Dec/2021:04:58:35 +0000] "GET /packages/92/96/144f70b972a9c0eabbd4391ef93ccd49d0f2747f4f6a2a2738e99e5adc65/requests-2.26.0-py2.py3-none-any.whl HTTP/1.1" 200 62251
user1_1             | Collecting charset-normalizer~=2.0.0
user1_1             |   Downloading http://pypi-nginx-cache/packages/47/84/b06f6729fac8108c5fa3e13cde19b0b3de66ba5538c325496dbe39f5ff8e/charset_normalizer-2.0.9-py3-none-any.whl (39 kB)
pypi-nginx-cache_1  | [CACHE MISS] 172.29.0.3 - - [05/Dec/2021:04:58:36 +0000] "GET /simple/urllib3/ HTTP/1.1" 200 11624
user1_1             | Installing collected packages: urllib3, idna, charset-normalizer, certifi, requests
pypi-nginx-cache_1  | [CACHE MISS] 172.29.0.3 - - [05/Dec/2021:04:58:36 +0000] "GET /packages/af/f4/524415c0744552cce7d8bf3669af78e8a069514405ea4fcbd0cc44733744/urllib3-1.26.7-py2.py3-none-any.whl HTTP/1.1" 200 138764
user1_1             | Successfully installed certifi-2021.10.8 charset-normalizer-2.0.9 idna-3.3 requests-2.26.0 urllib3-1.26.7
pypi-nginx-cache_1  | [CACHE MISS] 172.29.0.3 - - [05/Dec/2021:04:58:36 +0000] "GET /simple/idna/ HTTP/1.1" 200 4217
pypi-nginx-cache_1  | [CACHE MISS] 172.29.0.3 - - [05/Dec/2021:04:58:36 +0000] "GET /packages/04/a2/d918dcd22354d8958fe113e1a3630137e0fc8b44859ade3063982eacd2a4/idna-3.3-py3-none-any.whl HTTP/1.1" 200 61160
pypi-nginx-cache_1  | [CACHE MISS] 172.29.0.3 - - [05/Dec/2021:04:58:37 +0000] "GET /simple/certifi/ HTTP/1.1" 200 8101
user1_1             | WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
user1_1             | WARNING: You are using pip version 21.2.4; however, version 21.3.1 is available.
user1_1             | You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
pypi-nginx-cache_1  | [CACHE MISS] 172.29.0.3 - - [05/Dec/2021:04:58:37 +0000] "GET /packages/37/45/946c02767aabb873146011e665728b680884cd8fe70dde973c640e45b775/certifi-2021.10.8-py2.py3-none-any.whl HTTP/1.1" 200 149195
pypi-nginx-cache_1  | [CACHE MISS] 172.29.0.3 - - [05/Dec/2021:04:58:37 +0000] "GET /simple/charset-normalizer/ HTTP/1.1" 200 5721
pypi-nginx-cache_1  | [CACHE MISS] 172.29.0.3 - - [05/Dec/2021:04:58:37 +0000] "GET /packages/47/84/b06f6729fac8108c5fa3e13cde19b0b3de66ba5538c325496dbe39f5ff8e/charset_normalizer-2.0.9-py3-none-any.whl HTTP/1.1" 200 39257
pypi-nginx-cache_1  | [CACHE MISS] 172.29.0.3 - - [05/Dec/2021:04:58:40 +0000] "GET /simple/pip/ HTTP/1.1" 200 19865
pypi-nginx-cache_1  | 2021/12/05 04:58:41 [info] 33#33: *8 client 172.29.0.3 closed keepalive connection
pypi-nginx-cache_1  | 2021/12/05 04:58:41 [info] 33#33: *1 client 172.29.0.3 closed keepalive connection
pypi-nginx-cache_1  | 2021/12/05 04:58:41 [info] 33#33: *3 client 172.29.0.3 closed keepalive connection
pypi-nginx-cache_user1_1 exited with code 0
user2_1             | Looking in indexes: http://pypi-nginx-cache:8080/simple
pypi-nginx-cache_1  | [CACHE HIT] 172.29.0.3 - - [05/Dec/2021:04:58:51 +0000] "GET /simple/requests/ HTTP/1.1" 200 20295
user2_1             | Collecting requests
pypi-nginx-cache_1  | [CACHE HIT] 172.29.0.3 - - [05/Dec/2021:04:58:52 +0000] "GET /packages/92/96/144f70b972a9c0eabbd4391ef93ccd49d0f2747f4f6a2a2738e99e5adc65/requests-2.26.0-py2.py3-none-any.whl HTTP/1.1" 200 62251
user2_1             |   Downloading http://pypi-nginx-cache/packages/92/96/144f70b972a9c0eabbd4391ef93ccd49d0f2747f4f6a2a2738e99e5adc65/requests-2.26.0-py2.py3-none-any.whl (62 kB)
pypi-nginx-cache_1  | [CACHE HIT] 172.29.0.3 - - [05/Dec/2021:04:58:52 +0000] "GET /simple/idna/ HTTP/1.1" 200 4217
user2_1             | Collecting idna<4,>=2.5
pypi-nginx-cache_1  | [CACHE HIT] 172.29.0.3 - - [05/Dec/2021:04:58:52 +0000] "GET /packages/04/a2/d918dcd22354d8958fe113e1a3630137e0fc8b44859ade3063982eacd2a4/idna-3.3-py3-none-any.whl HTTP/1.1" 200 61160
user2_1             |   Downloading http://pypi-nginx-cache/packages/04/a2/d918dcd22354d8958fe113e1a3630137e0fc8b44859ade3063982eacd2a4/idna-3.3-py3-none-any.whl (61 kB)
pypi-nginx-cache_1  | [CACHE HIT] 172.29.0.3 - - [05/Dec/2021:04:58:52 +0000] "GET /simple/charset-normalizer/ HTTP/1.1" 200 5721
user2_1             | Collecting charset-normalizer~=2.0.0
pypi-nginx-cache_1  | [CACHE HIT] 172.29.0.3 - - [05/Dec/2021:04:58:52 +0000] "GET /packages/47/84/b06f6729fac8108c5fa3e13cde19b0b3de66ba5538c325496dbe39f5ff8e/charset_normalizer-2.0.9-py3-none-any.whl HTTP/1.1" 200 39257
user2_1             |   Downloading http://pypi-nginx-cache/packages/47/84/b06f6729fac8108c5fa3e13cde19b0b3de66ba5538c325496dbe39f5ff8e/charset_normalizer-2.0.9-py3-none-any.whl (39 kB)
pypi-nginx-cache_1  | [CACHE HIT] 172.29.0.3 - - [05/Dec/2021:04:58:52 +0000] "GET /simple/urllib3/ HTTP/1.1" 200 11624
user2_1             | Collecting urllib3<1.27,>=1.21.1
pypi-nginx-cache_1  | [CACHE HIT] 172.29.0.3 - - [05/Dec/2021:04:58:53 +0000] "GET /packages/af/f4/524415c0744552cce7d8bf3669af78e8a069514405ea4fcbd0cc44733744/urllib3-1.26.7-py2.py3-none-any.whl HTTP/1.1" 200 138764
user2_1             |   Downloading http://pypi-nginx-cache/packages/af/f4/524415c0744552cce7d8bf3669af78e8a069514405ea4fcbd0cc44733744/urllib3-1.26.7-py2.py3-none-any.whl (138 kB)
pypi-nginx-cache_1  | [CACHE HIT] 172.29.0.3 - - [05/Dec/2021:04:58:53 +0000] "GET /simple/certifi/ HTTP/1.1" 200 8101
user2_1             | Collecting certifi>=2017.4.17
pypi-nginx-cache_1  | [CACHE HIT] 172.29.0.3 - - [05/Dec/2021:04:58:53 +0000] "GET /packages/37/45/946c02767aabb873146011e665728b680884cd8fe70dde973c640e45b775/certifi-2021.10.8-py2.py3-none-any.whl HTTP/1.1" 200 149195
user2_1             |   Downloading http://pypi-nginx-cache/packages/37/45/946c02767aabb873146011e665728b680884cd8fe70dde973c640e45b775/certifi-2021.10.8-py2.py3-none-any.whl (149 kB)
user2_1             | Installing collected packages: urllib3, idna, charset-normalizer, certifi, requests
user2_1             | Successfully installed certifi-2021.10.8 charset-normalizer-2.0.9 idna-3.3 requests-2.26.0 urllib3-1.26.7
user2_1             | WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
pypi-nginx-cache_1  | [CACHE HIT] 172.29.0.3 - - [05/Dec/2021:04:58:55 +0000] "GET /simple/pip/ HTTP/1.1" 200 19865
user2_1             | WARNING: You are using pip version 21.2.4; however, version 21.3.1 is available.
user2_1             | You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
pypi-nginx-cache_1  | 2021/12/05 04:58:55 [info] 33#33: *11 client 172.29.0.3 closed keepalive connection
pypi-nginx-cache_1  | 2021/12/05 04:58:55 [info] 33#33: *9 client 172.29.0.3 closed keepalive connection
pypi-nginx-cache_1  | 2021/12/05 04:58:55 [info] 33#33: *10 client 172.29.0.3 closed keepalive connection
pypi-nginx-cache_user2_1 exited with code 0
```